### PR TITLE
fix(didRender): force didRender on revisiting same route

### DIFF
--- a/packages/ember-self-focused/addon/templates/components/self-focused.hbs
+++ b/packages/ember-self-focused/addon/templates/components/self-focused.hbs
@@ -1,1 +1,4 @@
+<div style="display: none">
+  {{#link-to 'application'}}{{/link-to}}
+</div>
 {{yield}}

--- a/packages/ember-self-focused/tests/acceptance/self-focused-test.js
+++ b/packages/ember-self-focused/tests/acceptance/self-focused-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { click, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | self focused', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting the same route focuses the desired HTML node - home', async function(assert) {
+    await visit('/');
+
+    await click('[href');
+    assert.equal(document.activeElement, document.querySelector('.home'));
+
+    await click('[href');
+    assert.equal(document.activeElement, document.querySelector('.home'));
+
+    await click('[href');
+    assert.equal(document.activeElement, document.querySelector('.home'));
+  });
+
+  test('visiting the same route focuses the desired HTML node - about', async function(assert) {
+    await visit('/');
+
+    await click('[href$=about');
+    assert.equal(document.activeElement, document.querySelector('.about'));
+
+    await click('[href$=about');
+    assert.equal(document.activeElement, document.querySelector('.about'));
+
+    await click('[href$=about');
+    assert.equal(document.activeElement, document.querySelector('.about'));
+  });
+
+  test('visiting the same route focuses the desired HTML node - topics', async function(assert) {
+    await visit('/');
+
+    await click('[href$=topics');
+    assert.equal(document.activeElement, document.querySelector('.topics'));
+
+    await click('[href$=topics');
+    assert.equal(document.activeElement, document.querySelector('.topics'));
+
+    await click('[href$=topics');
+    assert.equal(document.activeElement, document.querySelector('.topics'));
+  });
+
+  test('visiting the same route focuses the desired HTML node - topics/component', async function(assert) {
+    await visit('/topics');
+
+    await click('[href$=component');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+
+    await click('[href$=component');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+
+    await click('[href$=component');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+  });
+
+  test('visiting the same route focuses the desired HTML node - topics/router', async function(assert) {
+    await visit('/topics');
+
+    await click('[href$=router');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+
+    await click('[href$=router');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+
+    await click('[href$=router');
+    assert.equal(document.activeElement, document.querySelector('.topic'));
+  });
+});

--- a/packages/ember-self-focused/tests/dummy/app/templates/about.hbs
+++ b/packages/ember-self-focused/tests/dummy/app/templates/about.hbs
@@ -1,3 +1,3 @@
-{{#self-focused}}
+{{#self-focused class="about"}}
   <h2>About</h2>
 {{/self-focused}}

--- a/packages/ember-self-focused/tests/dummy/app/templates/home.hbs
+++ b/packages/ember-self-focused/tests/dummy/app/templates/home.hbs
@@ -1,3 +1,3 @@
-{{#self-focused}}
+{{#self-focused class="home"}}
   <h2>Home</h2>
 {{/self-focused}}

--- a/packages/ember-self-focused/tests/dummy/app/templates/topics.hbs
+++ b/packages/ember-self-focused/tests/dummy/app/templates/topics.hbs
@@ -1,4 +1,4 @@
-{{#self-focused}}
+{{#self-focused class="topics"}}
   <h2>Topics</h2>
   <ul>
    <li>

--- a/packages/ember-self-focused/tests/dummy/app/templates/topics/topic.hbs
+++ b/packages/ember-self-focused/tests/dummy/app/templates/topics/topic.hbs
@@ -1,3 +1,3 @@
-{{#self-focused}}
+{{#self-focused class="topic"}}
   <h3>{{model.topicId}}</h3>
 {{/self-focused}}


### PR DESCRIPTION
using a hidden `{{link-to}}` to force re-render

fixes #2 

---

I noticed, that if there is a `{{link-to}}` component present in the template, the component is re-rendered on visiting the same route. 

Same can be witnessed in the dummy app.

After loading:

- Click "Topics"
- Click "Topics"
- Click "Topics"
- ...
- Observe focus state set at the "Topics" level every time.

Thus added a `{{link-to}}` component wrapped in a `div` with style `display:none`.

Using `display:none` on an element will not only hide it from the display but will also remove it from the accessibility tree. 

This will cause the element and all its descendant elements to no longer be announced by screen reading technology.