### PR TITLE
refactor(scrollTo): Refactoring window.scrollTo to document.body.scrollTop/scrollLeft to avoid focus race condition in Safari 12

### DIFF
--- a/packages/ember-self-focused/addon/services/focus-manager.js
+++ b/packages/ember-self-focused/addon/services/focus-manager.js
@@ -96,8 +96,12 @@ export default Service.extend({
       const scrollY = window.pageYOffset;
       node.setAttribute('tabindex', '-1');
       node.focus();
-      // after setting focus, scroll back to the place where the user was previously
-      window.scrollTo(scrollX, scrollY);
+      // After setting focus, scroll back to the place where the user was previously.
+      // We are now using document.body.scrollLeft/scrollTop rather than window.scrollTo
+      // because in Safari 12 there is an issue where the scroll that happens internally
+      // from focusing clobbers window.scrollTo
+      document.body.scrollLeft = scrollX;
+      document.body.scrollTop = scrollY;
       // mouse click on a element with tabindex=-1 focuses the element
       // thus removing the tabindex on blur or click
       node.addEventListener('blur', this._removeTabIndex);

--- a/packages/react-self-focused/src/focus-manager.js
+++ b/packages/react-self-focused/src/focus-manager.js
@@ -46,8 +46,12 @@ class FocusManager {
             const scrollY = window.pageYOffset;
             nodeToBeFocused.setAttribute('tabindex', '-1');
             nodeToBeFocused.focus();
-            // After setting focus, scroll back to the place where the user was previously
-            window.scrollTo(scrollX, scrollY);
+            // After setting focus, scroll back to the place where the user was previously.
+            // We are now using document.body.scrollLeft/scrollTop rather than window.scrollTo
+            // because in Safari 12 there is an issue where the scroll that happens internally
+            // from focusing clobbers window.scrollTo
+            document.body.scrollLeft = scrollX;
+            document.body.scrollTop = scrollY;
             // Mouse click on a element with tabindex=-1 focuses the element
             // thus removing the tabindex on blur or click
             nodeToBeFocused.addEventListener('blur', removeTabIndex);


### PR DESCRIPTION
To fix issue #10 we want to use document.body.scrollLeft/scrollTop rather than window.scrollTo because in Safari 12 there is an issue where the scroll that happens internally from focusing clobbers window.scrollTo

