### PR TITLE
test(settled): using settled instead of nested rAF

### DIFF
--- a/packages/ember-self-focused/README.md
+++ b/packages/ember-self-focused/README.md
@@ -37,6 +37,34 @@ Since the div will be focused, it will have a focus outline/highlight, if that i
 }
 ```
 
+If there are tests in the consuming application that is testing `div.self-focused` to be the `document.activeElement` as a result of `set`, please use `settled` like so:
+
+```js
+import { render, settled} from '@ember/test-helpers';
+...
+
+module('some module', function(hooks) {
+  ...
+
+  test('some test', async function(assert) {
+    this.set('one', null);
+
+    await render(hbs`
+      <div id="container">
+        {{#self-focused class="one" one=one}}
+          template block text
+        {{/self-focused}}
+      </div>
+    `);
+
+    this.set('one', 'foo');
+    await settled();
+    let selfFocusedDiv = this.element.querySelector('#container .one');
+    assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> one has a tabindex property with value -1');
+  });
+}
+```
+
 Implementation overview
 ------------------------------------------------------------------------------
 

--- a/packages/ember-self-focused/tests/integration/components/self-focused-test.js
+++ b/packages/ember-self-focused/tests/integration/components/self-focused-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render} from '@ember/test-helpers';
+import { render, settled} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | self-focused', function(hooks) {
@@ -141,7 +141,6 @@ module('Integration | Component | self-focused', function(hooks) {
   });
 
   test('it should focus the child most self-focused div on re-render', async function(assert) {
-    const done = assert.async();
     this.set('one', null);
     this.set('two', null);
     this.set('three', null);
@@ -159,25 +158,21 @@ module('Integration | Component | self-focused', function(hooks) {
     `);
 
     this.set('one', 'foo');
-    requestAnimationFrame(() => {
-      let selfFocusedDiv = this.element.querySelector('#container .one');
-      assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> one has a tabindex property with value -1');
-      assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> one is the currently focused element');
+    await settled();
+    let selfFocusedDiv = this.element.querySelector('#container .one');
+    assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> one has a tabindex property with value -1');
+    assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> one is the currently focused element');
 
-      this.set('two', 'foo');
-      requestAnimationFrame(() => {
-        selfFocusedDiv = this.element.querySelector('#container .two');
-        assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> two has a tabindex property with value -1');
-        assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> two is the currently focused element');
+    this.set('two', 'foo');
+    await settled();
+    selfFocusedDiv = this.element.querySelector('#container .two');
+    assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> two has a tabindex property with value -1');
+    assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> two is the currently focused element');
 
-        this.set('three', 'foo');
-        requestAnimationFrame(() => {
-          selfFocusedDiv = this.element.querySelector('#container .three');
-          assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> three has a tabindex property with value -1');
-          assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> three is the currently focused element');
-          done();
-        });
-      });
-    });
+    this.set('three', 'foo');
+    await settled();
+    selfFocusedDiv = this.element.querySelector('#container .three');
+    assert.equal(selfFocusedDiv.getAttribute('tabindex'), '-1', 'self-focused <div> three has a tabindex property with value -1');
+    assert.equal(selfFocusedDiv, document.activeElement, 'self-focused <div> three is the currently focused element');
   });
 });


### PR DESCRIPTION
refactored tests to use `settled` as suggested by @krisselden

no breaking changes